### PR TITLE
changed np.float_ to np.float64 to work with newer numpy version

### DIFF
--- a/rawread.py
+++ b/rawread.py
@@ -61,7 +61,7 @@ def rawread(fname: str):
                 rowdtype = np.dtype({'names': plot['varnames'],
                                      'formats': [np.complex_ if b'complex'
                                                  in plot[b'flags']
-                                                 else np.float_]*nvars})
+                                                 else np.float64]*nvars})
                 # We should have all the metadata by now
                 arrs.append(np.fromfile(fp, dtype=rowdtype, count=npoints))
                 plots.append(plot)


### PR DESCRIPTION
Fixed small bug. Before fix I got this error:
"AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead."